### PR TITLE
better rust CI: maintained actions, caching

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay-rust-toolchain@1.69.0
+      - uses: Swatinem/rust-cache@v2
       - name: Install protoc
         uses: arduino/setup-protoc@v1
         with:
@@ -71,6 +72,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay-rust-toolchain@1.69.0
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
       - name: Install protoc
         uses: arduino/setup-protoc@v1
         with:
@@ -79,8 +84,5 @@ jobs:
         with:
           version: "1.17.0"
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: dtolnay-rust-toolchain@1.69.0
-        with:
-          components: clippy
       - name: run clippy
         run: clippy --all --all-targets -- -D warnings


### PR DESCRIPTION
This PR replaces the `action-rs` actions and explicitly calling `rustup install` with the `dtolnay/rust-toolchain` and explicitly calling `cargo {test,fmt,clippy}`.  `cargo fmt` is not run with `+nightly`, which is required for #18.

The main reason for this is that `actions-rs` is unmaintained, while `dtolnay/rust-toolchain` is actively maintained by one of the most important rust ecosystem contributors.

While at it, this PR also:

1. bumps buf to `1.17`
2. fixes the rust compiler to `1.69.0`
3. uses the same `arduino/setup-protoc` action throughout
4. splits up cargo test compilation and test-execution
5. and introduces the `Swatinem/rust-cache@v2` action to speed up builds.